### PR TITLE
Adding support for Graalvisor after filesystem-related changes.

### DIFF
--- a/source/pi/warble.py
+++ b/source/pi/warble.py
@@ -16,21 +16,31 @@ def main():
     argparser.add_argument('-u', '--username', required=False, help='username')
     #argparser.add_argument('-t', '--tweet', required=False, help='tweet')
     argparser.add_argument('-r', '--url', required=False, help='url')
+    argparser.add_argument('-m', '--mode', required=False, help='mode')
     args = argparser.parse_args()
     input = args.code
     username = args.username
+    mode = args.mode
     #url = args.url
     #tweet = args.tweet
     # Hard coding URL because passed in as an argument it doesn't work for some reason.
     url = "https://g2f4dc3e5463897-ardata.adb.uk-london-1.oraclecloudapps.com/ords/picluster/AR/warble/"
+    gv_url = "http://127.0.0.1:8080"
 
     if args.verbose:
         utils.verbose = True
 
     linput = input.replace("\"", "\\\"")
 
-    stream = os.popen('python3 ../warble/warblecc.py --username {} \"{}\"'.format(username, linput))
-    output = stream.read()
+    if mode == "graalvisor" or mode == "gv":
+        data = { "name": "warble", "async": "false", "arguments": '["--username", "{}", "{}"]'.format(username, linput) }
+        headers = {'Content-type': 'application/json'}
+        r = requests.post(gv_url, data=json.dumps(data), headers=headers)
+        result = json.loads(r.text)["result"].replace("'", "\"")
+        output = json.loads(result)["result"]
+    else:
+        stream = os.popen('python3 ../warble/warblecc.py --username {} \"{}\"'.format(username, linput))
+        output = stream.read()
 
     try:
         data = { "username": username, "code": input, "output": output }

--- a/source/pi/warble.sh
+++ b/source/pi/warble.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+function check_environment {
+  export WARBLE_HOME=$DIR/../warble
+  if [ -z "$JAVA_HOME" ] || [ -z "$GRAALVISOR_PATH" ]
+  then
+    echo "Please check your environment variables."
+    exit 1
+  fi
+}
+
+function start_graalvisor {
+  export lambda_timestamp="$(date +%s%N | cut -b1-13)"
+  export lambda_port="$GRAALVISOR_PORT"
+  $GRAALVISOR_PATH
+}
+
+function register_function {
+  curl -s -X POST $GRAALVISOR_IP:$GRAALVISOR_PORT/register?name=warble\&entryPoint=main\&language=python -H 'Content-Type: application/json' --data-binary @$WARBLE_HOME/gv-warble-entrypoint.py
+}
+
+if [[ "$*" == *"-m graalvisor"* ]] || [[ "$*" == *"-m=graalvisor"* ]]
+then
+  # Prepare Graalvisor.
+  check_environment
+  GRAALVISOR_IP=127.0.0.1
+  GRAALVISOR_PORT=8080
+  # Checking if the default port of Graalvisor is in use.
+  if [ -z "$(lsof -i -P -n | grep LISTEN | grep $GRAALVISOR_PORT)" ]
+  then
+    # Graalvisor is down, we have to launch it and register the function.
+    start_graalvisor &
+    sleep 5
+    register_function
+  fi
+fi
+
+python3 $DIR/warble.py "$@"

--- a/source/warble/gv-warble-entrypoint.py
+++ b/source/warble/gv-warble-entrypoint.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import io
+from contextlib import redirect_stdout
 
 sys.path.insert(0, os.environ['WARBLE_HOME'])
 import warblecc
@@ -8,7 +10,10 @@ def warble(argv):
     sys.argv = [ "warblecc.py" ]
     for item in eval(argv):
         sys.argv.append(item)
-    warblecc.main()
+    f = io.StringIO()
+    with redirect_stdout(f):
+        warblecc.main()
+    return f.getvalue()
 
 def main(args):
     try:


### PR DESCRIPTION
In this PR, I am changing the `warble.py` script by adding the `-m` or `--mode` optional argument. If the value of this argument is `graalvisor`, then Graalvisor will be used to run Warble. Otherwise, Warble will be run with plain Python.
Besides that, I have changed the Python entry point for Graalvisor so that now it gathers the `stdout` of the Warble programs.
Lastly, I have (re-)introduced the `warble.sh` script that is now intended to setup Graalvisor infrastructure, and then delegate to the `warble.py` script with the original arguments, passed to the `warble.sh` script.

With these changes, in order to run Warble in Python mode, you can run the `warble.py` **Python** script directly (as it was previously), or run it through the `warble.sh` **Bash** script with the same arguments (since it will anyway delegate to the `warble.py` script):
```
python3 warble.py -u user "{PRINT(\"test\")}"
OR
bash warble.sh -u user "{PRINT(\"test\")}"
```
If you want to run Warble in Graalvisor mode, you should run it through the `warble.sh` **Bash** script (at least for the first time, to start and configure Graalvisor), and add the `-m graalvisor` or `-m=graalvisor` argument to your command:
```
bash warble.sh -u user -m graalvisor "{PRINT(\"test\")}"
```
Note that executing Warble in Graalvisor mode still requires the `$GRAALVISOR_PATH` environment variable to be pointing to the Graalvisor binary, and the `$JAVA_HOME` environment variable to be pointing to the JVM folder containing the required GraalPython libraries.